### PR TITLE
Fixed error

### DIFF
--- a/MyTime/Control.gd
+++ b/MyTime/Control.gd
@@ -55,6 +55,10 @@ func _on_FileDialog_popup_hide():
 func roll_date_back(days):
 	var last_day = end.get_date()
 	
+	if last_day["day"] == "" or last_day["month"] == "" or last_day["year"] == "":
+		end.set_date()
+		last_day = end.get_date()
+	
 	last_day = OS.get_unix_time_from_datetime(last_day) - (days * 24 * 60 * 60) # times hours, minutes, seconds
 	var temp = Dictionary()
 	temp["startDate"] = last_day

--- a/MyTime/Scenes/HelperScenes/FileSave.tscn
+++ b/MyTime/Scenes/HelperScenes/FileSave.tscn
@@ -9,7 +9,6 @@ anchor_bottom = 1.0
 script = ExtResource( 1 )
 
 [node name="FileDialog" type="FileDialog" parent="."]
-visible = true
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5


### PR DESCRIPTION
Fix for date issue when selecting a date range and no end date is picked before picking the number of days prior. now it assumes that the end date is the current day if nothing was entered. 

Fix for issue #16 